### PR TITLE
Add skip call when logging with fields at all levels

### DIFF
--- a/examples/logging.yaml
+++ b/examples/logging.yaml
@@ -3,22 +3,45 @@
 # SPDX-License-Identifier: Apache-2.0
 
 encoders:
+  console:
+    fields:
+      - message
+      - name
+      - level:
+          format: uppercase
+      - timestamp:
+          format: ISO8601
+      - caller #:
+      #format: short
+      #- stacktrace
   json:
     fields:
       - message:
           key: message
+      - name:
+          key: logger
       - level:
-          format: uppercase
-      - caller:
-          format: short
+          key: level
+          format: lowercase
       - timestamp:
-          format: iso8601
+          key: time
+          format: ISO8601
+      - caller:
+          key: caller
+          format: short
+      #- stacktrace:
+      #    key: trace
 
 writers:
   stdout:
+    encoder: console
+  file:
+    path: ./example.log
     encoder: json
 
 rootLogger:
-  level: info
+  level: debug
   outputs:
-    - stdout
+    - stdout:
+        level: info
+    - file

--- a/examples/logging.yaml
+++ b/examples/logging.yaml
@@ -3,45 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
 encoders:
-  console:
-    fields:
-      - message
-      - name
-      - level:
-          format: uppercase
-      - timestamp:
-          format: ISO8601
-      - caller #:
-          #format: short
-      #- stacktrace
   json:
     fields:
       - message:
           key: message
-      - name:
-          key: logger
       - level:
-          key: level
-          format: lowercase
-      - timestamp:
-          key: time
-          format: ISO8601
+          format: uppercase
       - caller:
-          key: caller
           format: short
-      #- stacktrace:
-      #    key: trace
+      - timestamp:
+          format: iso8601
 
 writers:
   stdout:
-    encoder: console
-  file:
-    path: ./example.log
     encoder: json
 
 rootLogger:
-  level: debug
+  level: info
   outputs:
-    - stdout:
-        level: info
-    - file
+    - stdout

--- a/examples/main.go
+++ b/examples/main.go
@@ -17,5 +17,5 @@ var log = dazl.GetPackageLogger()
 const projectName = "dazl"
 
 func main() {
-	log.Infof("%s is a logging framework for Go", projectName)
+	log.Infow("dazl is a logging framework for Go", dazl.String("foo", "bar"))
 }

--- a/logger.go
+++ b/logger.go
@@ -470,7 +470,7 @@ func (l *dazlLogger) Debugf(format string, args ...any) {
 }
 
 func (l *dazlLogger) Debugw(msg string, fields ...Field) {
-	l.WithFields(fields...).Debug(msg)
+	l.WithFields(fields...).WithSkipCalls(1).Debug(msg)
 }
 
 func (l *dazlLogger) Info(args ...any) {
@@ -490,7 +490,7 @@ func (l *dazlLogger) Infof(format string, args ...any) {
 }
 
 func (l *dazlLogger) Infow(msg string, fields ...Field) {
-	l.WithFields(fields...).Info(msg)
+	l.WithFields(fields...).WithSkipCalls(1).Info(msg)
 }
 
 func (l *dazlLogger) Warn(args ...any) {
@@ -510,7 +510,7 @@ func (l *dazlLogger) Warnf(format string, args ...any) {
 }
 
 func (l *dazlLogger) Warnw(msg string, fields ...Field) {
-	l.WithFields(fields...).Warn(msg)
+	l.WithFields(fields...).WithSkipCalls(1).Warn(msg)
 }
 
 func (l *dazlLogger) Error(args ...any) {
@@ -530,7 +530,7 @@ func (l *dazlLogger) Errorf(format string, args ...any) {
 }
 
 func (l *dazlLogger) Errorw(msg string, fields ...Field) {
-	l.WithFields(fields...).Error(msg)
+	l.WithFields(fields...).WithSkipCalls(1).Error(msg)
 }
 
 func (l *dazlLogger) Fatal(args ...any) {
@@ -550,7 +550,7 @@ func (l *dazlLogger) Fatalf(format string, args ...any) {
 }
 
 func (l *dazlLogger) Fatalw(msg string, fields ...Field) {
-	l.WithFields(fields...).Fatal(msg)
+	l.WithFields(fields...).WithSkipCalls(1).Fatal(msg)
 }
 
 func (l *dazlLogger) Panic(args ...any) {
@@ -570,7 +570,7 @@ func (l *dazlLogger) Panicf(format string, args ...any) {
 }
 
 func (l *dazlLogger) Panicw(msg string, fields ...Field) {
-	l.WithFields(fields...).Panic(msg)
+	l.WithFields(fields...).WithSkipCalls(1).Panic(msg)
 }
 
 var _ Logger = &dazlLogger{}

--- a/logger_test.go
+++ b/logger_test.go
@@ -352,6 +352,7 @@ func TestLoggerMethods(t *testing.T) {
 	}))
 
 	stdout.EXPECT().WithName(gomock.Eq("test")).Return(stdout)
+	stdout.EXPECT().WithSkipCalls(gomock.Eq(1)).Return(stdout).AnyTimes()
 	log := GetLogger("test")
 
 	stdout.EXPECT().Debug(gomock.Eq("debug"))


### PR DESCRIPTION
This PR fixes a bug in the caller output due to needing to skip another caller level when using the `*w` logger methods.